### PR TITLE
allow individual endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Configure extension in your `config.neon` file:
 aws:
 	region: eu-west-1
 	version: latest
+	endpoint: (optional - when ommited, Amazon AWS URL is used)
 ```
 
 And put your key and secret in your `config.local.neon` file (which should not be versioned)

--- a/src/DI/AwsSdkNetteExtension.php
+++ b/src/DI/AwsSdkNetteExtension.php
@@ -16,6 +16,7 @@ class AwsSdkNetteExtension extends Nette\DI\CompilerExtension
 	private $defaults = [
 		'region' => NULL,
 		'version' => 'latest',
+		'endpoint' => NULL,
 		'credentials' => [
 			'key' => NULL,
 			'secret' => NULL


### PR DESCRIPTION
Add an *endpoint* configuration key to ease use of other S3 storage (like private MinIO instance).